### PR TITLE
17 requirement on dask

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run:
           name: "Install prerequisites"
-          command: pip install pytest sphinx dask matplotlib
+          command: pip install pytest sphinx matplotlib
       - run:
           name: "Install package"
           command: pip install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-06-07
+### Fixed
+- Included dask as an explicit dependency
+
 ## [1.2] - 2023-04-14
 ### Added
 - Ambient input from ROMS ocean model

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     netcdf4
     holoviews
     scipy
+    dask
     tomli
 python_requires = >=3.6
 


### PR DESCRIPTION
Closes #17

Thanks @castelao for taking the time to review this submission. I am already using a continuous integration server (CircleCI), which should have been able to catch this error. However, I had erroneously believed that dask was only required for testing, not for actual usage of the package, and had factored out dask from the installation requirements. On closer inspection, I see that multi-file io with xarray requires dask, so it should be included in the regular installation requirements.