### PR TITLE
Remove error on warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ testpaths =
     tests
 filterwarnings =
     error
+    ignore:Converting non-nanosecond precision datetime values to nanosecond precision:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ minversion = 6.0
 addopts = -ra -q
 testpaths =
     tests
+filterwarnings =
+    error


### PR DESCRIPTION
The CI server now checks for warnings. A specific warning regarding pandas handling of datetime64 precision is ignored.