### PR TITLE
Use os-dependent line terminator in csv files

### DIFF
--- a/src/effluent/io.py
+++ b/src/effluent/io.py
@@ -366,7 +366,6 @@ class OutputCSV(Output):
         # Append result to file, write headers only if blank file
         df.to_csv(
             self.dset,
-            lineterminator='\n',
             header=self._blank_file,
             float_format=self.float_format,
             index=False,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -300,13 +300,13 @@ class Test_Output_from_config:
             out.write(time=1, result=result)
             txt = buf.getvalue()
 
-        assert txt == dedent("""
-            release_time,t,x,y,z,u,v,w,density,radius
-            0,1000,1,3,5,7,9,2,4,6
-            0,2000,2,4,6,8,1,3,5,7
-            1,1000,1,3,5,7,9,2,4,6
-            1,2000,2,4,6,8,1,3,5,7
-         """)[1:]
+        assert txt.replace('\r', '') == (
+            "release_time,t,x,y,z,u,v,w,density,radius\n"
+            "0,1000,1,3,5,7,9,2,4,6\n"
+            "0,2000,2,4,6,8,1,3,5,7\n"
+            "1,1000,1,3,5,7,9,2,4,6\n"
+            "1,2000,2,4,6,8,1,3,5,7\n"
+        )
 
     def test_option_nc_file(self, result):
         buf = xr.Dataset()
@@ -352,4 +352,4 @@ class Test_Output_from_config:
             buf.seek(0)
             first_line = buf.readline()
 
-        assert first_line == "release_time,x,z,y\n"
+        assert first_line.replace('\r', '') == "release_time,x,z,y\n"


### PR DESCRIPTION
Background: The lineterminator argument to to_csv is not backwards-compatible. By removing it, we generate csv files with os-dependent line terminator character, which is probably a good idea anyway.