### PR TITLE
Add reference to worked examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The software is invoked as a command line script:
     effluent config.toml
 
 where `config.toml` is the configuration file specifying the simulation
-setup.
+setup. Examples of valid configuration files are given in the repository
+directory `docs/source/examples`, and in the
+[online documentation](https://effluent.readthedocs.io/en/latest/).
 
 
 # Documentation

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,3 +1,5 @@
+.. _examples_page:
+
 =============
 Examples
 =============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,13 +59,8 @@ or from within python as
 
 In both cases, simulation details are specified in the
 file ``config.toml``, written in the `TOML file format <https://toml.io/en/>`_.
-A samle config file is shown below:
-
-.. literalinclude:: examples/jet/config.toml
-    :language: toml
-
-Other input and output formats are also available. See the rest of the
-documentation for details.
+The :ref:`examples_page` section includes many examples of valid config files,
+for various types of problems.
 
 
 Documentation


### PR DESCRIPTION
Add reference to worked examples in the readme file, and in the front page of the documentation.