### PR TITLE
Adding conda environment files both for regular usage and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ these analyses are conducted in post-processing stages using other packages.
 
 # Installation
 
-The package is installed using pip:
+The package can be installed using pip:
 
     pip install effluent
+
+Alternatively, a [conda environment](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#) 
+file (`environment.yml`) is included that creates an isolated python environment for Effluent.
+The environment can be created by:
+
+    conda env create -f environment.yml
 
 
 # Usage

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: Effluent
+
+dependencies:
+ - python>=3.7
+ - netCDF4>=1.4
+ - matplotlib>=3.1
+ - pip
+ - pip:
+   - git+https://github.com/pnsaevik/effluent

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# Effluent Tests
+
+Running the tests requires adding `pytest` to the conda environment.
+The file `test_environment.yml` includes this addition, so that `conda env create -f test_environment.yml` will create an appropriate environment for running the test suite.
+
+To run the tests, simply activate the environment (`conda activate EffluentPyTest` and call `pytest`).
+The tests should take around a minute to run.

--- a/tests/test_environment.yml
+++ b/tests/test_environment.yml
@@ -1,0 +1,10 @@
+name: EffluentPyTest
+
+dependencies:
+ - python>=3.7
+ - netCDF4>=1.4
+ - matplotlib>=3.1
+ - pytest
+ - pip
+ - pip:
+   - git+https://github.com/pnsaevik/effluent


### PR DESCRIPTION
If you want them, here's the yml configuration file that I used for testing Effluent. I've also modified the README to mention conda usage.

For the sake of clarity / fairness, this is **_not_** a requirement for the JOSS publication, and you should feel free to reject the pull request if you choose to.

**NOTE:** The yml file currently points to the git repo when installing, instead of pip. Will need to update the yml when the pip version is updated with the latest changes.